### PR TITLE
Fix GradScaler initialization syntax

### DIFF
--- a/superbotb_highres_cached.py
+++ b/superbotb_highres_cached.py
@@ -335,7 +335,10 @@ def train_model(model, train_loader, val_loader, num_epochs=100, learning_rate=1
     history = {'train_loss': [], 'val_loss': [], 'train_error': [], 'val_error': []}
     
     # Mixed precision scaler (single declaration)
-    scaler = torch.amp.GradScaler('cuda') if device.type == 'cuda' else None
+    if device.type == 'cuda':
+        scaler = torch.amp.GradScaler('cuda')
+    else:
+        scaler = None
     
     for epoch in range(start_epoch, num_epochs):
         model.train()

--- a/superbotb_highres_cached_patched.py
+++ b/superbotb_highres_cached_patched.py
@@ -404,7 +404,10 @@ def train_model(
     history = {"train_loss": [], "val_loss": [], "train_error": [], "val_error": []}
 
     # Mixed precision scaler (single declaration)
-    scaler = torch.amp.GradScaler("cuda") if device.type == "cuda" else None
+    if device.type == "cuda":
+        scaler = torch.amp.GradScaler("cuda")
+    else:
+        scaler = None
 
     epochs_no_improve = 0
     if auto_mode and early_stop_patience is None:


### PR DESCRIPTION
## Summary
- Prevent syntax errors during profiling by replacing a ternary expression with an explicit `if/else` when initializing `torch.amp.GradScaler`.

## Testing
- `python -m py_compile superbotb_highres_cached.py`
- `python -m py_compile superbotb_highres_cached_patched.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2ccfdb4808332935a9e468042ffad