### PR TITLE
Normalize Gaussian heatmap targets

### DIFF
--- a/spotball_enhanced_model2.py
+++ b/spotball_enhanced_model2.py
@@ -246,6 +246,8 @@ def create_gaussian_heatmap(coords_norm, heatmap_size=HEATMAP_SIZE, sigma=2.0):
 
     heatmap[y, x] = 1.0
     heatmap = gaussian_filter(heatmap, sigma=sigma)
+    heatmap /= heatmap.max()
+    # Normalizing preserves a sharp peak for stable training
 
     return heatmap
 


### PR DESCRIPTION
## Summary
- normalize generated Gaussian heatmaps to keep max value at 1
- clarify that normalization preserves a sharp peak for training stability

## Testing
- `python -m py_compile spotball_enhanced_model2.py`
- `python spotball_enhanced_model2.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c33725fa7c8332a1c26c74e3c8a548