### PR TITLE
Force matplotlib to use Agg backend

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -14,6 +14,8 @@ import torch.optim as optim
 from torch.utils.data import Dataset, DataLoader
 import timm
 from tqdm import tqdm
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import cv2
 from sklearn.model_selection import train_test_split


### PR DESCRIPTION
## Summary
- configure matplotlib to use the non-interactive Agg backend in codexfpn training script
- prevent Tkinter-related runtime errors when saving plots during training

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd279ce55883328ac0b05f29e3b8ab