### PR TITLE
Use logits for heatmap loss

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -303,7 +303,10 @@ class CombinedLoss(nn.Module):
         self.coord_weight = coord_weight
 
     def forward(self, pred_heatmaps, target_heatmaps, pred_coords=None, target_coords=None):
-        pred_heatmaps = torch.sigmoid(pred_heatmaps)
+        # Leave heatmap logits unclamped so the MSE loss can propagate
+        # healthy gradients even when the network is very confident about
+        # foreground pixels. Visualization utilities downstream still
+        # apply sigmoid before rendering.
         h_loss = self.heatmap_loss(pred_heatmaps, target_heatmaps)
 
         if pred_coords is not None and target_coords is not None:


### PR DESCRIPTION
## Summary
- update the combined loss to operate directly on heatmap logits so gradients are not squashed
- keep visualization helpers untouched so they still render sigmoid probabilities when saving samples

## Testing
- python codexfpn.py *(fails: ModuleNotFoundError: No module named 'numpy' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6f9f16d48332ab176e443cba4be9