### PR TITLE
Disable persistent dataloader workers for sigma annealing

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -1100,7 +1100,7 @@ def main():
         shuffle=True,
         num_workers=Config.NUM_WORKERS,
         pin_memory=True,
-        persistent_workers=Config.NUM_WORKERS > 0
+        persistent_workers=False  # allow heatmap sigma updates to reach workers each epoch
     )
 
     val_loader = DataLoader(
@@ -1109,7 +1109,7 @@ def main():
         shuffle=False,
         num_workers=Config.NUM_WORKERS,
         pin_memory=True,
-        persistent_workers=Config.NUM_WORKERS > 0
+        persistent_workers=False
     )
 
     print(f"\n✅ Dataloaders created successfully")


### PR DESCRIPTION
## Summary
- disable persistent dataloader workers so each epoch picks up the updated heatmap sigma value
- apply the same change to the validation loader for consistency

## Testing
- python -m compileall codexfpn.py

------
https://chatgpt.com/codex/tasks/task_e_68cea1dd02948332954ed9869ac81b9d