### PR TITLE
Detach BCE weight from autograd

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -392,7 +392,11 @@ class CombinedLoss(nn.Module):
                 (1.0 - prob).pow(2.0),
                 prob.pow(2.0),
             )
-            weight = bright_weight * (1.0 + focal_modulation)
+            # Detach the dynamically generated weight tensor.  BCE-with-logits does not
+            # support gradient propagation through the ``weight`` argument, so we ensure
+            # it remains a statically valued tensor while still reflecting the latest
+            # prediction-dependent modulation.
+            weight = (bright_weight * (1.0 + focal_modulation)).detach()
 
             h_loss = F.binary_cross_entropy_with_logits(
                 pred_heatmaps_fp32,


### PR DESCRIPTION
## Summary
- detach the dynamically computed weight tensor in CombinedLoss so that BCE-with-logits can accept it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d05a6a5d8c8332bdecdb0dfbd9e1a2