### PR TITLE
Suppress low-confidence heatmap fusion weights

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -225,6 +225,11 @@ def compute_heatmap_fusion_weight(heatmap_logits):
         mean = flattened.mean(dim=1)
 
         confidence = (peak - mean) / (peak + 1e-6)
+        confidence = torch.where(
+            confidence >= Config.HEATMAP_CONFIDENCE_THRESHOLD,
+            confidence,
+            torch.zeros_like(confidence),
+        )
         confidence = confidence.clamp_(0.0, 1.0)
 
         if Config.HEATMAP_CONFIDENCE_SCALE != 1.0:


### PR DESCRIPTION
## Summary
- zero out heatmap fusion weights when their confidence is below the configured threshold
- retain final clamping and optional scaling to keep weights within [0, 1]

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06d9279248332866267863189ac6e