### PR TITLE
Rebalance losses and temper heatmap fusion gate

### DIFF
--- a/tests/test_combined_loss.py
+++ b/tests/test_combined_loss.py
@@ -25,7 +25,7 @@ def test_combined_loss_pushes_max_probability_above_half():
     # Run a miniature training loop that mimics a single epoch worth of updates.
     for _ in range(120):
         optimizer.zero_grad()
-        total_loss, h_loss, c_loss = criterion(logits, target)
+        total_loss, h_loss, c_loss, pixel_loss = criterion(logits, target)
         total_loss.backward()
         optimizer.step()
 
@@ -33,3 +33,4 @@ def test_combined_loss_pushes_max_probability_above_half():
         probs = torch.sigmoid(logits)
 
     assert probs.max().item() > 0.5, "weighted BCE should push the peak probability well above 0.5"
+    assert pixel_loss.item() == pytest.approx(0.0), "pixel loss should be zero when coordinates are absent"


### PR DESCRIPTION
## Summary
- add configuration hooks to slow the heatmap gate warmup, enforce a minimum regressor contribution, and tune default loss weights
- extend the combined loss with a pixel-space regression term and plumb the additional statistics through training/validation summaries while disabling mixup by default
- adjust the CombinedLoss unit test to validate the expanded return signature and new pixel-loss behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08559d3d483329e891e8af2acbfa2