### PR TITLE
Handle filtered albumentations kwargs

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -173,12 +173,20 @@ def instantiate_albumentations_transform(transform_cls, common_kwargs, candidate
     errors: list[str] = []
     for candidate_kwargs in candidate_kwargs_list:
         filtered_kwargs = candidate_kwargs
+        dropped_all_kwargs = False
         if allowed_keys is not None:
             filtered_kwargs = {
                 key: value
                 for key, value in candidate_kwargs.items()
                 if key in allowed_keys
             }
+            dropped_all_kwargs = bool(candidate_kwargs) and not filtered_kwargs
+
+        if dropped_all_kwargs:
+            # The candidate only contained unsupported kwargs.  Skip straight to
+            # the next option rather than instantiating the transform with just
+            # the common arguments.
+            continue
 
         try:
             return transform_cls(**common_kwargs, **filtered_kwargs)

--- a/tests/test_instantiate_albumentations_transform.py
+++ b/tests/test_instantiate_albumentations_transform.py
@@ -1,0 +1,45 @@
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("torch")
+pytest.importorskip("cv2")
+pytest.importorskip("albumentations")
+
+from codexfpn import instantiate_albumentations_transform
+
+
+def test_skips_candidate_when_all_kwargs_filtered():
+    class DummyTransform:
+        def __init__(self, *, border_mode=None, value=None):
+            self.border_mode = border_mode
+            self.value = value
+
+    common_kwargs = {"p": 0.5}
+    candidates = [
+        {"mode": "legacy", "cval": 123},
+        {"border_mode": "reflect", "value": 0},
+    ]
+
+    transform = instantiate_albumentations_transform(
+        DummyTransform,
+        common_kwargs,
+        candidates,
+    )
+
+    assert isinstance(transform, DummyTransform)
+    assert transform.border_mode == "reflect"
+    assert transform.value == 0
+
+
+def test_returns_common_kwargs_when_candidate_empty():
+    class DummyTransform:
+        def __init__(self, *, foo=0):
+            self.foo = foo
+
+    transform = instantiate_albumentations_transform(
+        DummyTransform,
+        {"foo": 10},
+        [{}],
+    )
+
+    assert transform.foo == 10


### PR DESCRIPTION
## Summary
- ensure `instantiate_albumentations_transform` skips candidates whose kwargs are completely filtered out so that later aliases can be tried
- add regression tests for the helper to cover the empty-filter scenario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d45529f7888332bbcd371c8228b5e4