### PR TITLE
Align loss balancer with pixel penalty

### DIFF
--- a/tests/test_combined_loss.py
+++ b/tests/test_combined_loss.py
@@ -25,7 +25,10 @@ def test_combined_loss_pushes_max_probability_above_half():
     # Run a miniature training loop that mimics a single epoch worth of updates.
     for _ in range(120):
         optimizer.zero_grad()
-        total_loss, h_loss, c_loss, pixel_loss = criterion(logits, target)
+        total_loss, h_loss, c_loss, pixel_loss, pixel_penalty, center_loss = criterion(
+            logits,
+            target,
+        )
         total_loss.backward()
         optimizer.step()
 
@@ -34,3 +37,5 @@ def test_combined_loss_pushes_max_probability_above_half():
 
     assert probs.max().item() > 0.5, "weighted BCE should push the peak probability well above 0.5"
     assert pixel_loss.item() == pytest.approx(0.0), "pixel loss should be zero when coordinates are absent"
+    assert pixel_penalty.item() == pytest.approx(0.0), "pixel penalty should be zero when coordinates are absent"
+    assert center_loss.item() == pytest.approx(0.0), "center loss should be zero when disabled"


### PR DESCRIPTION
## Summary
- expose the log-shaped pixel-space penalty alongside the raw MAE in `CombinedLoss`
- propagate the new value through training/validation so logging and the loss balancer can reason about the true optimiser objective
- update the loss balancer to weight pixel contributions by the penalty term and extend the unit test to cover the new outputs

## Testing
- pytest *(skipped: torch is not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e439ecb88332a4d7561e1ae8c610