### PR TITLE
Tame pixel penalty contribution in balancer

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -740,6 +740,7 @@ class LossBalanceController:
         heatmap_loss: float,
         coord_loss: float,
         pixel_loss: float,
+        pixel_penalty: float,
         criterion: "CombinedLoss",
     ) -> None:
         if not self.enabled:
@@ -751,10 +752,29 @@ class LossBalanceController:
             getattr(criterion, 'pixel_coord_weight', self.state.pixel_coord_loss_weight)
         )
 
+        penalty_for_balance = float(pixel_penalty)
+        log_scale = float(getattr(Config, 'PIXEL_LOSS_LOG_SCALE', 0.0))
+        if log_scale > 0.0:
+            # ``pixel_penalty`` is scaled by ``log_scale`` inside ``CombinedLoss`` so the
+            # optimiser keeps receiving gradients on the order of the raw MAE.  When we
+            # compare branch contributions, however, the inflated magnitude makes the
+            # regressor appear to dominate even after the balancer clamps its weight.  A
+            # more faithful proxy for the actual gradient pressure is the unscaled
+            # log-penalty (roughly ``log1p(error / log_scale)``), so we divide by the same
+            # factor here.  We also ensure the contribution never falls below the normalised
+            # pixel MAE so that, if the log penalty is disabled mid-run, the controller
+            # smoothly transitions back to MAE-based accounting.
+            penalty_for_balance = penalty_for_balance / log_scale
+            image_extent = max(float(Config.IMAGE_SIZE - 1), 1.0)
+            normalised_mae = float(pixel_loss) / image_extent
+            penalty_for_balance = max(penalty_for_balance, normalised_mae)
+        else:
+            penalty_for_balance = float(pixel_loss)
+
         weighted_losses = {
             'heatmap': heatmap_weight * heatmap_loss,
             'coord': coord_weight * coord_loss,
-            'pixel': pixel_weight * pixel_loss,
+            'pixel': pixel_weight * penalty_for_balance,
         }
 
         total = weighted_losses['heatmap'] + weighted_losses['coord'] + weighted_losses['pixel']
@@ -1079,6 +1099,7 @@ class CombinedLoss(nn.Module):
             total_loss = self.heatmap_weight * h_loss
             c_loss = pred_heatmaps_fp32.new_tensor(0.0)
             pixel_loss = pred_heatmaps_fp32.new_tensor(0.0)
+            pixel_penalty = pred_heatmaps_fp32.new_tensor(0.0)
             center_loss = pred_heatmaps_fp32.new_tensor(0.0)
 
             if (
@@ -1133,11 +1154,10 @@ class CombinedLoss(nn.Module):
                             torch.log1p(pixel_abs_error / log_scale).mean() * log_scale
                         )
 
+                    pixel_penalty = loss_term
                     total_loss = total_loss + self.pixel_coord_weight * loss_term
 
-        outputs = (total_loss, h_loss, c_loss, pixel_loss)
-        if target_coords_fp32 is not None or self.heatmap_center_weight > 0.0:
-            outputs = outputs + (center_loss,)
+        outputs = (total_loss, h_loss, c_loss, pixel_loss, pixel_penalty, center_loss)
 
         return outputs
 
@@ -1531,6 +1551,7 @@ def train_one_epoch(
     total_heatmap_loss = 0.0
     total_coord_loss = 0.0
     total_pixel_loss = 0.0
+    total_pixel_penalty = 0.0
     total_center_loss = 0.0
 
     num_batches = len(dataloader)
@@ -1572,19 +1593,34 @@ def train_one_epoch(
             pred_heatmaps, pred_coords = model(images)
 
             if target_b is not None and coords_b is not None:
-                loss_a, h_loss_a, c_loss_a, p_loss_a, ctr_loss_a = criterion(
+                (
+                    loss_a,
+                    h_loss_a,
+                    c_loss_a,
+                    p_loss_a,
+                    p_penalty_a,
+                    ctr_loss_a,
+                ) = criterion(
                     pred_heatmaps, target_a, pred_coords, coords_a
                 )
-                loss_b, h_loss_b, c_loss_b, p_loss_b, ctr_loss_b = criterion(
+                (
+                    loss_b,
+                    h_loss_b,
+                    c_loss_b,
+                    p_loss_b,
+                    p_penalty_b,
+                    ctr_loss_b,
+                ) = criterion(
                     pred_heatmaps, target_b, pred_coords, coords_b
                 )
                 loss = lam * loss_a + (1 - lam) * loss_b
                 h_loss = lam * h_loss_a + (1 - lam) * h_loss_b
                 c_loss = lam * c_loss_a + (1 - lam) * c_loss_b
                 p_loss = lam * p_loss_a + (1 - lam) * p_loss_b
+                p_penalty = lam * p_penalty_a + (1 - lam) * p_penalty_b
                 center_loss = lam * ctr_loss_a + (1 - lam) * ctr_loss_b
             else:
-                loss, h_loss, c_loss, p_loss, center_loss = criterion(
+                loss, h_loss, c_loss, p_loss, p_penalty, center_loss = criterion(
                     pred_heatmaps, target_a, pred_coords, coords_a
                 )
 
@@ -1599,6 +1635,7 @@ def train_one_epoch(
         total_heatmap_loss += h_loss.item()
         total_coord_loss += c_loss.item()
         total_pixel_loss += p_loss.item()
+        total_pixel_penalty += p_penalty.item()
         total_center_loss += center_loss.item()
 
         processed_batches += 1
@@ -1632,6 +1669,7 @@ def train_one_epoch(
                 'h_loss': f"{h_loss.item():.4f}",
                 'c_loss': f"{c_loss.item():.4f}",
                 'p_loss': f"{p_loss.item():.4f}",
+                'p_pen': f"{p_penalty.item():.4f}",
                 'ctr': f"{center_loss.item():.4f}",
             }
         )
@@ -1642,9 +1680,10 @@ def train_one_epoch(
     avg_h_loss = total_heatmap_loss / effective_batches
     avg_c_loss = total_coord_loss / effective_batches
     avg_p_loss = total_pixel_loss / effective_batches
+    avg_p_penalty = total_pixel_penalty / effective_batches
     avg_ctr_loss = total_center_loss / effective_batches
 
-    return avg_loss, avg_h_loss, avg_c_loss, avg_p_loss, avg_ctr_loss
+    return avg_loss, avg_h_loss, avg_c_loss, avg_p_loss, avg_p_penalty, avg_ctr_loss
 
 def validate(model, dataloader, criterion, device, epoch):
     """Validate the model and compute metrics."""
@@ -1655,6 +1694,7 @@ def validate(model, dataloader, criterion, device, epoch):
     all_errors = []
     fusion_weight_log = []
     total_pixel_loss = 0.0
+    total_pixel_penalty = 0.0
     total_center_loss = 0.0
 
     progress_bar = tqdm(dataloader, desc=f"Validation Epoch {epoch+1}", colour="yellow")
@@ -1674,7 +1714,7 @@ def validate(model, dataloader, criterion, device, epoch):
             # Forward pass
             with autocast(**_autocast_kwargs_for(device)):
                 pred_heatmaps, pred_coords = model(images)
-                loss, _, _, pixel_loss, center_loss = criterion(
+                loss, _, _, pixel_loss, pixel_penalty, center_loss = criterion(
                     pred_heatmaps,
                     target_heatmaps,
                     pred_coords,
@@ -1683,6 +1723,7 @@ def validate(model, dataloader, criterion, device, epoch):
 
             total_loss += loss.item()
             total_pixel_loss += pixel_loss.item()
+            total_pixel_penalty += pixel_penalty.item()
             total_center_loss += center_loss.item()
             
             # Extract coordinates from heatmap for evaluation
@@ -1726,9 +1767,11 @@ def validate(model, dataloader, criterion, device, epoch):
             })
     
     # Aggregate metrics
-    avg_loss = total_loss / len(dataloader)
-    avg_pixel_loss = total_pixel_loss / len(dataloader)
-    avg_center_loss = total_center_loss / len(dataloader)
+    num_batches = max(len(dataloader), 1)
+    avg_loss = total_loss / num_batches
+    avg_pixel_loss = total_pixel_loss / num_batches
+    avg_pixel_penalty = total_pixel_penalty / num_batches
+    avg_center_loss = total_center_loss / num_batches
     all_preds = torch.cat(all_preds)
     all_targets = torch.cat(all_targets)
     
@@ -1761,6 +1804,7 @@ def validate(model, dataloader, criterion, device, epoch):
         all_errors,
         {
             'pixel_loss': avg_pixel_loss,
+            'pixel_penalty': avg_pixel_penalty,
             'center_loss': avg_center_loss,
             'heatmap_mae': mae_heatmap,
             'regressor_mae': mae_regressor,
@@ -2263,7 +2307,14 @@ def main():
         print(f"Learning rates: {lr_report}")
 
         # Training phase
-        train_loss, train_h_loss, train_c_loss, train_p_loss, train_ctr_loss = train_one_epoch(
+        (
+            train_loss,
+            train_h_loss,
+            train_c_loss,
+            train_p_loss,
+            train_p_penalty,
+            train_ctr_loss,
+        ) = train_one_epoch(
             model,
             train_loader,
             optimizer,
@@ -2275,7 +2326,13 @@ def main():
             grad_accum_steps=Config.GRAD_ACCUM_STEPS,
         )
 
-        loss_balancer.observe(train_h_loss, train_c_loss, train_p_loss, criterion)
+        loss_balancer.observe(
+            train_h_loss,
+            train_c_loss,
+            train_p_loss,
+            train_p_penalty,
+            criterion,
+        )
 
         # Validation phase
         if (epoch + 1) % Config.VALIDATE_EVERY_N_EPOCHS == 0:
@@ -2297,11 +2354,12 @@ def main():
             print(
                 "  Train Loss: "
                 f"{train_loss:.4f} (H: {train_h_loss:.4f}, C: {train_c_loss:.4f}, "
-                f"Px: {train_p_loss:.4f}, Ctr: {train_ctr_loss:.4f})"
+                f"Px: {train_p_loss:.4f} [log {train_p_penalty:.4f}], "
+                f"Ctr: {train_ctr_loss:.4f})"
             )
             print(
                 "  Val Loss: "
-                f"{val_loss:.4f} (Px: {val_stats['pixel_loss']:.4f}, "
+                f"{val_loss:.4f} (Px: {val_stats['pixel_loss']:.4f} [log {val_stats['pixel_penalty']:.4f}], "
                 f"Ctr: {val_stats['center_loss']:.4f}, "
                 f"HM-MAE: {val_stats['heatmap_mae']:.2f}px, Reg-MAE: {val_stats['regressor_mae']:.2f}px, "
                 f"w_hm: {val_stats['fusion_weight']:.2f})"

--- a/tests/test_combined_loss.py
+++ b/tests/test_combined_loss.py
@@ -25,7 +25,10 @@ def test_combined_loss_pushes_max_probability_above_half():
     # Run a miniature training loop that mimics a single epoch worth of updates.
     for _ in range(120):
         optimizer.zero_grad()
-        total_loss, h_loss, c_loss, pixel_loss = criterion(logits, target)
+        total_loss, h_loss, c_loss, pixel_loss, pixel_penalty, center_loss = criterion(
+            logits,
+            target,
+        )
         total_loss.backward()
         optimizer.step()
 
@@ -34,3 +37,5 @@ def test_combined_loss_pushes_max_probability_above_half():
 
     assert probs.max().item() > 0.5, "weighted BCE should push the peak probability well above 0.5"
     assert pixel_loss.item() == pytest.approx(0.0), "pixel loss should be zero when coordinates are absent"
+    assert pixel_penalty.item() == pytest.approx(0.0), "pixel penalty should be zero when coordinates are absent"
+    assert center_loss.item() == pytest.approx(0.0), "center loss should be zero when disabled"


### PR DESCRIPTION
## Summary
- scale the pixel branch contribution that the loss balancer observes by the log-penalty factor and normalised MAE so it reflects gradient pressure instead of raw penalty magnitude

## Testing
- pytest *(skipped: torch is not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e439ecb88332a4d7561e1ae8c610