### PR TITLE
Handle RandomResizedCrop size parameter

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -583,12 +583,15 @@ def load_checkpoint(
 
 
 def build_transforms() -> Tuple[A.BasicTransform, A.BasicTransform]:
-    random_resized_crop = A.RandomResizedCrop(
-        height=Config.IMAGE_SIZE,
-        width=Config.IMAGE_SIZE,
-        scale=(0.55, 1.0),
-        ratio=(0.75, 1.33),
-        interpolation=cv2.INTER_CUBIC,
+    random_resized_crop = instantiate_albumentations_transform(
+        A.RandomResizedCrop,
+        dict(scale=(0.55, 1.0), ratio=(0.75, 1.33), interpolation=cv2.INTER_CUBIC),
+        [
+            {"height": Config.IMAGE_SIZE, "width": Config.IMAGE_SIZE},
+            {"size": Config.IMAGE_SIZE},
+            {"size": (Config.IMAGE_SIZE, Config.IMAGE_SIZE)},
+            {"size": [Config.IMAGE_SIZE, Config.IMAGE_SIZE]},
+        ],
     )
 
     affine = instantiate_albumentations_transform(


### PR DESCRIPTION
## Summary
- instantiate the Albumentations RandomResizedCrop transform through the compatibility helper so both legacy and new argument names are supported
- add fallbacks for height/width and tuple-based size specifications to satisfy the updated schema validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d56f32810c833283574d685bef4e7f