### PR TITLE
Handle validation errors when instantiating transforms

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -120,13 +120,13 @@ def instantiate_albumentations_transform(
                 continue
         try:
             return transform_cls(**common_kwargs, **filtered)
-        except TypeError as exc:
+        except (TypeError, ValueError) as exc:
             errors.append(str(exc))
             continue
 
     try:
         return transform_cls(**common_kwargs)
-    except TypeError as exc:
+    except (TypeError, ValueError) as exc:
         errors.append(str(exc))
         attempted.append({})
         raise TypeError(


### PR DESCRIPTION
## Summary
- treat Albumentations validation errors the same as type errors when probing constructor kwargs
- ensure instantiation falls back to alternative parameter shapes when ValueError is raised

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d57043e0608332a147d6400dc64ad9