### PR TITLE
Add optional context metadata branch to coordinate regression pipeline

### DIFF
--- a/tests/test_dataset_keypoint_bounds.py
+++ b/tests/test_dataset_keypoint_bounds.py
@@ -43,10 +43,11 @@ def test_rotated_sample_targets_stay_in_range(tmp_path):
         transform=transform,
     )
 
-    image_tensor, precise_coords, path = dataset[0]
+    image_tensor, precise_coords, context, path = dataset[0]
 
     assert image_tensor.shape == (3, Config.IMAGE_SIZE, Config.IMAGE_SIZE)
     assert precise_coords.shape == (2,)
+    assert context is None
     assert path.endswith(".jpg")
 
     assert torch.all(precise_coords >= 0.0)
@@ -57,6 +58,7 @@ def test_rotated_sample_targets_stay_in_range(tmp_path):
     assert torch.all(image_coords <= Config.IMAGE_SIZE - 1)
 
     # The second sample should fall back to the first if its keypoint is dropped
-    image_tensor_2, precise_coords_2, _ = dataset[1]
+    image_tensor_2, precise_coords_2, context_2, _ = dataset[1]
     assert torch.allclose(image_tensor, image_tensor_2)
     assert torch.allclose(precise_coords, precise_coords_2)
+    assert context_2 is None


### PR DESCRIPTION
## Summary
- add configuration knobs and helpers to ingest per-frame context metadata vectors
- extend the coordinate regression model and training loop to fuse the optional context branch
- update dataset tests to reflect the richer sample tuple returned by the dataset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b47e0dec8332a372b121336c1cb2