### PR TITLE
Handle missing context metadata during batching

### DIFF
--- a/codexfpn.py
+++ b/codexfpn.py
@@ -337,11 +337,14 @@ def get_context_features(image_path: str) -> Optional[torch.Tensor]:
     the expected numeric format.
     """
     if not Config.CONTEXT_METADATA_ENABLED:
-        return None
+        # The dataloader's default collate function cannot handle ``None``
+        # entries inside a batch.  Returning a zero-length tensor keeps the
+        # signature consistent without enabling the context branch.
+        return torch.zeros(0, dtype=torch.float32)
 
     vector_length = max(int(Config.CONTEXT_VECTOR_SIZE), 0)
     if vector_length == 0:
-        return None
+        return torch.zeros(0, dtype=torch.float32)
 
     meta_path = _context_metadata_path(image_path)
     values = _read_context_metadata(meta_path)


### PR DESCRIPTION
## Summary
- ensure `get_context_features` always returns a tensor
- avoid DataLoader collate errors when context metadata is disabled or empty

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c6614fe08332814ea9b97c8e870f