### PR TITLE
Ensure weighted loss reductions run in float32

### DIFF
--- a/tests/test_loss_precision.py
+++ b/tests/test_loss_precision.py
@@ -1,0 +1,22 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from train_ball_localizer import TrainingConfig, compute_weighted_loss_components
+
+
+def test_weighted_loss_float32_reduction():
+    config = TrainingConfig(
+        heatmap_fg_weight=10_000.0,
+        heatmap_bg_weight=0.0,
+    )
+
+    loss_map = torch.full((1, 1, 32, 32), 100.0, dtype=torch.float16)
+    targets = torch.ones_like(loss_map)
+
+    loss, _, weight_sum = compute_weighted_loss_components(loss_map, targets, config)
+
+    assert torch.isfinite(loss), "Normalised loss should remain finite in float32"
+    assert torch.isfinite(weight_sum), "Weight reduction should occur in float32"
+    assert loss.dtype == torch.float32
+    assert weight_sum.dtype == torch.float32


### PR DESCRIPTION
## Summary
- run the weighted loss reductions in float32 outside the autocast scope to avoid overflow when AMP is active
- reuse the same float32 reductions during validation for consistent logging
- add a regression test that exercises the loss normalisation with half precision inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e394b2685c8332af0e76e17250fdb5