### PR TITLE
Remove heatmap decode offset

### DIFF
--- a/tests/test_heatmap_decode_alignment.py
+++ b/tests/test_heatmap_decode_alignment.py
@@ -1,0 +1,38 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+
+from train_ball_localizer import TrainingConfig, ValidationSampleExporter, compute_metrics
+
+
+def test_compute_metrics_returns_unbiased_coordinates():
+    config = TrainingConfig(input_size=256, heatmap_size=4)
+
+    outputs = torch.zeros((1, 1, 4, 4))
+    outputs[0, 0, 1, 2] = 10.0
+
+    batch = {
+        "pad": torch.zeros(1, 2),
+        "scale": torch.ones(1),
+        "original_xy": torch.tensor([[128.0, 64.0]]),
+    }
+
+    metrics = compute_metrics(outputs, batch, config)
+
+    assert metrics["pixel_mae"] == pytest.approx(0.0)
+    assert metrics["pixel_median"] == pytest.approx(0.0)
+    assert metrics["pixel_errors"] == [0.0]
+
+
+def test_decode_heatmap_matches_encoding(tmp_path):
+    config = TrainingConfig(input_size=256, heatmap_size=4)
+    exporter = ValidationSampleExporter(tmp_path, config, max_samples=0)
+
+    heatmap = np.zeros((4, 4), dtype=np.float32)
+    heatmap[1, 2] = 1.0
+
+    decoded_x, decoded_y = exporter._decode_heatmap(heatmap)
+
+    assert decoded_x == pytest.approx(128.0)
+    assert decoded_y == pytest.approx(64.0)

--- a/train_ball_localizer.py
+++ b/train_ball_localizer.py
@@ -420,8 +420,8 @@ def compute_metrics(
         b, _, h, w = probs.shape
         flat = probs.view(b, -1)
         indices = torch.argmax(flat, dim=1)
-        pred_y = (indices // w).float() + 0.5
-        pred_x = (indices % w).float() + 0.5
+        pred_y = (indices // w).float()
+        pred_x = (indices % w).float()
 
         # Convert to the training canvas coordinate system.
         pred_x_canvas = pred_x * (config.input_size / config.heatmap_size)
@@ -586,8 +586,8 @@ class ValidationSampleExporter:
     def _decode_heatmap(self, heatmap: np.ndarray) -> tuple[float, float]:
         h, w = heatmap.shape
         flat_idx = int(np.argmax(heatmap))
-        y = (flat_idx // w) + 0.5
-        x = (flat_idx % w) + 0.5
+        y = float(flat_idx // w)
+        x = float(flat_idx % w)
         scale = self.config.input_size / self.config.heatmap_size
         return x * scale, y * scale
 


### PR DESCRIPTION
## Summary
- remove the 0.5-cell bias when decoding argmax heatmap coordinates in both metric computation and validation exports
- add regression coverage to ensure decoded coordinates align with the encoded target grid

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e3b3f456c48332bbbf0e8d05428104