### PR TITLE
Fix heatmap loss weighting to improve localisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tests/test_loss_precision.py
+++ b/tests/test_loss_precision.py
@@ -14,9 +14,10 @@ def test_weighted_loss_float32_reduction():
     loss_map = torch.full((1, 1, 32, 32), 100.0, dtype=torch.float16)
     targets = torch.ones_like(loss_map)
 
-    loss, _, weight_sum = compute_weighted_loss_components(loss_map, targets, config)
+    loss, fg_loss, bg_loss = compute_weighted_loss_components(
+        loss_map, targets, config
+    )
 
-    assert torch.isfinite(loss), "Normalised loss should remain finite in float32"
-    assert torch.isfinite(weight_sum), "Weight reduction should occur in float32"
-    assert loss.dtype == torch.float32
-    assert weight_sum.dtype == torch.float32
+    for component in (loss, fg_loss, bg_loss):
+        assert torch.isfinite(component), "Loss components should remain finite"
+        assert component.dtype == torch.float32


### PR DESCRIPTION
## Summary
- rework the heatmap loss computation to upcast reductions, split foreground/background terms, and log both components during training
- adjust training and validation loops to average per-sample losses with the new weighting scheme
- update the loss precision test expectations and add a gitignore for Python bytecode artifacts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e48b85aa4c833280e0f2091ccb6e3e