### PR TITLE
Fix RandomResizedCrop configuration for Albumentations 2.x

### DIFF
--- a/train_ball_localizer.py
+++ b/train_ball_localizer.py
@@ -322,7 +322,8 @@ class BotbBallDataset(Dataset):
         ):
             transforms.append(
                 A.RandomResizedCrop(
-                    size=(height, width),
+                    height=height,
+                    width=width,
                     scale=(
                         self.config.spatial_crop_scale_min,
                         self.config.spatial_crop_scale_max,


### PR DESCRIPTION
## Summary
- update the RandomResizedCrop augmentation to use explicit height/width parameters compatible with Albumentations 2.x

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e54cd0581483329fbca536ea478e36